### PR TITLE
fix(): make underline position the same as ms word

### DIFF
--- a/src/document-parser.ts
+++ b/src/document-parser.ts
@@ -1305,6 +1305,7 @@ export class DocumentParser {
 			case "single":
 			case "thick":
 				style["text-decoration"] = "underline";
+				style["text-underline-position"] = "from-font";
 				break;
 
 			case "wave":


### PR DESCRIPTION
> [!NOTE]  
> I don't build the source to avoid conflicts from other PRs.

### Before fix

<img width="493" alt="image" src="https://github.com/VolodymyrBaydalka/docxjs/assets/2031404/446da05e-ac2c-4ada-a760-f25c34166adf">

The left is docxjs: the space between underline and text is 1 px.
The right is MS Word: the space between underline and text is 2 px.

### After fix

<img width="560" alt="image" src="https://github.com/VolodymyrBaydalka/docxjs/assets/2031404/a8edf14c-c66c-4161-b0c5-7de46a26bb49">
