### PR TITLE
Fix smallCaps CSS style

### DIFF
--- a/src/document-parser.ts
+++ b/src/document-parser.ts
@@ -1162,7 +1162,7 @@ export class DocumentParser {
 					break;
 
 				case "smallCaps":
-					style["text-transform"] = xml.boolAttr(c, "val", true) ? "lowercase" : "none";
+					style["font-variant"] = xml.boolAttr(c, "val", true) ? "small-caps" : "none";
 					break;
 
 				case "u":


### PR DESCRIPTION
Hello Volodymyr,

First off, thank you for this great library. This PR is a simple one-line code change to improve the HTML rendered docx preview for documents that contain **small-caps**. 

## Issue

Documents which contain the [OOXML smallCaps tag](https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_smallCaps_topic_ID0EY2YO.html) are being rendered in HTML as lowercase text. See image.

>Note: The first two lines of text and the table headers are all using small-caps. They all appear as lowercase letters in the docxjs preview.

<img width="1282" alt="smallcaps-issue-example" src="https://github.com/VolodymyrBaydalka/docxjs/assets/152421239/72592023-45c4-4cf1-bff8-99aed901a578">

## Solution

Because your code was already detecting the OOXML tag for smallCaps, it was easy to modify which style was being applied. CSS has a style which can implement smallCaps in the browser. `font-variant: small-caps`.

```js
case "smallCaps":
    style["text-transform"] = xml.boolAttr(c, "val", true) ? "lowercase" : "none";
    break;
```
<img width="1311" alt="solution-example" src="https://github.com/VolodymyrBaydalka/docxjs/assets/152421239/1cc30d1c-e9d8-4a46-b635-423828bd63eb">

## Other Considerations

- `font-variant` has the same **broad** browser compatibility support as `text-transform`.
- You could instead use the longhand style `font-variant-caps: small-caps`. It works the same. 
- This PR includes the **source code change ONLY**. It **does not** include re-bundled JS necessary for the package to be distributed. This was for simplicity's sake. 
