### PR TITLE
Fix openXmlPackage load file bug

### DIFF
--- a/src/common/open-xml-package.ts
+++ b/src/common/open-xml-package.ts
@@ -15,7 +15,8 @@ export class OpenXmlPackage {
     }
 
     get(path: string): any {
-        return this._zip.files[normalizePath(path)];
+		const _path = normalizePath(path)
+        return this._zip.files[_path] || this._zip.files[_path.replace(/\//g, '\\')];
     }
 
     update(path: string, content: any) {


### PR DESCRIPTION
When JSZIP parses some files, backslashes are displayed in the path. As a result, files cannot be matched through the path.

![image](https://github.com/VolodymyrBaydalka/docxjs/assets/48666585/17ba72dc-df27-45a0-b883-bcbe31900625)

You can reproduce the problem with this file: [Linux.docx](https://github.com/VolodymyrBaydalka/docxjs/files/14602751/Linux.docx)

So I try to match the file with the backslash path when the path with the slash does not match the file.

