### PR TITLE
Use package.exports for better compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,11 @@
     "dist"
   ],
   "type": "module",
-  "module": "dist/docx-preview.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/docx-preview.mjs",
+      "require": "./dist/docx-preview.js"
+    }
+  },
   "types": "dist/docx-preview.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "files": [
     "dist"
   ],
-  "type": "module",
   "exports": {
     ".": {
       "import": "./dist/docx-preview.mjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "importHelpers": false,
     "esModuleInterop": true,
     "target": "ES2020",
-    "outDir": "dist",
+    "noEmit": true,
     "lib": [
       "ES2017",
       "dom"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "ES2022",
+    "moduleResolution": "bundler",
     "declaration": false,
     "noImplicitAny": false,
     "noEmitOnError": true,


### PR DESCRIPTION
Hey!

I'd like to suggest this change in `package.json` which should make the package more interoperable.

The `exports` field is the standard way to specify the "main" module and is [universally supported by most runtimes and bundlers](https://webpack.js.org/guides/package-exports/#support). The currently used `module` field does not work in Node.js and even a simple `import {} from 'docx-preview'` will fail.

I also removed `"type": "module"`, as it is not correct. The property is meant to specify whether `.js` files in the package are to be interpreted as ES modules or CommonJS. And right now `dist/*.js` are all CommonJS modules. If you wanted to keep `"type": "module"`, you'd need to rename those files to `.cjs`.

Finally, I also added `moduleResolution` to `tsconfig.json` so that the `jszip` import would resolve properly.

With these changes, it will be possible to load `docx-preview` from both ES and CommonJS modules.