### PR TITLE
Fix package.json to export types

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   "exports": {
     ".": {
       "import": "./dist/docx-preview.mjs",
-      "require": "./dist/docx-preview.js"
+      "require": "./dist/docx-preview.js",
+      "types": "./dist/docx-preview.d.ts"
     }
   },
   "types": "dist/docx-preview.d.ts"


### PR DESCRIPTION
After updating to 3.0.1, I got the following error message while type-checking my project which uses `docx-preview`:

```text
Could not find a declaration file for module 'docx-preview'. 'C:/dev/my_project/node_modules/docx-preview/dist/docx-preview.mjs' implicitly has an 'any' type.
  There are types at 'C:/dev/my_project/node_modules/docx-preview/dist/docx-preview.d.ts', but this result could not be resolved when respecting package.json "exports". The 'docx-preview' library may need to update its package.json or typings.
```
This pull request fixes that error.


-----
With release 3.0.1, `tsc --build --force` on a project that imports `'docx-preview'` fails on type checking.

The reason seems to be that "exports" was added three weeks ago (and made its way into release 3.0.1), but the "types" subfield was not declared in the "exports" field.

This commit fixes the issue `tsc --build` works fine for downstream projects.