### PR TITLE
Fix: Hyperlinks with anchor tags are correctly rendered

### DIFF
--- a/src/document-parser.ts
+++ b/src/document-parser.ts
@@ -587,11 +587,13 @@ export class DocumentParser {
 		var anchor = xml.attr(node, "anchor");
 		var relId = xml.attr(node, "id");
 
-		if (anchor)
-			result.href = "#" + anchor;
+		if (anchor) {
+			result.anchor = anchor;
+		}
 
-		if (relId)
+		if (relId) {
 			result.id = relId;
+		}
 
 		xmlUtil.foreach(node, c => {
 			switch (c.localName) {

--- a/src/document/dom.ts
+++ b/src/document/dom.ts
@@ -89,6 +89,7 @@ export abstract class OpenXmlElementBase implements OpenXmlElement {
 export interface WmlHyperlink extends OpenXmlElement {
 	id?: string;
     href?: string;
+	anchor?: string;
 }
 
 export interface WmlSmartTag extends OpenXmlElement {

--- a/src/html-renderer.ts
+++ b/src/html-renderer.ts
@@ -943,13 +943,20 @@ section.${c}>footer { z-index: 1; }
 
 		if (elem.href) {
 			result.href = elem.href;
-		} else if(elem.id) {
-			const rel = this.document.documentPart.rels
-				.find(it => it.id == elem.id && it.targetMode === "External");
-			result.href = rel?.target;
+		} else if (elem.id) {
+			const rel = this.getRelationshipById(elem.id);
+			if (rel && rel.targetMode === "External") {
+				result.href = rel.target + (elem.anchor ? "#" + elem.anchor : "");
+			}
+		} else if (elem.anchor) {
+			result.href = window.location.href.split('#')[0] + "#" + elem.anchor;
 		}
-
+		
 		return result;
+	}
+
+	getRelationshipById(id: string): { id: string, target: string, targetMode: string } | undefined {
+		return this.document.documentPart.rels.find(it => it.id === id);
 	}
 	
 	renderSmartTag(elem: WmlSmartTag) {


### PR DESCRIPTION
### Summary
This PR fixes an issue where hyperlinks with anchor tags (#) are incorrectly treated as local links. Right now, if a document has an external link with an anchor, it’s being parsed as a local link.

### Problem
With the current setup, links to external sites with anchor tags end up looking like local URLs. For instance:

Original Link: https://github.com/VolodymyrBaydalka/docxjs#test_anchor
Incorrectly Parsed Link: http://localhost:9876/debug.html#test_anchor
This messes up the URL, which could cause navigation issues.

### Solution
This update fixes the parsing so that external links with anchors are handled correctly. The link will now be preserved as intended.

Original Link: https://github.com/VolodymyrBaydalka/docxjs#test_anchor
Correctly Parsed Link: https://github.com/VolodymyrBaydalka/docxjs#test_anchor