### PR TITLE
fix(table-text-rotation): rotated text in table cell is correctly rendered

### DIFF
--- a/src/document-parser.ts
+++ b/src/document-parser.ts
@@ -1146,6 +1146,34 @@ export class DocumentParser {
 
 			return true;
 		});
+
+		this.parseTableCellVerticalText(elem, cell);
+	}
+
+	parseTableCellVerticalText(elem: Element, cell: WmlTableCell) {
+		const directionMap = {
+			"btLr": {
+				writingMode: "vertical-rl",
+				transform: "rotate(180deg)"
+			},
+			"lrTb": {
+				writingMode: "vertical-lr",
+				transform: "none"
+			},
+			"tbRl": {
+				writingMode: "vertical-rl",
+				transform: "none"
+			}
+		};
+
+		xmlUtil.foreach(elem, c => {
+			if (c.localName === "textDirection") {
+				const direction = xml.attr(c, "val");
+				const style = directionMap[direction] || {writingMode: "horizontal-tb"};
+				cell.cssStyle["writing-mode"] = style.writingMode;
+				cell.cssStyle["transform"] = style.transform;
+			}
+		});
 	}
 
 	parseDefaultProperties(elem: Element, style: Record<string, string> = null, childStyle: Record<string, string> = null, handler: (prop: Element) => boolean = null): Record<string, string> {


### PR DESCRIPTION
### Summary
This PR fixes an issue where rotated text in table cells was not being rendered correctly. The text now appears as intended.

### Problem
Previously, if text in a table cell was rotated, it wasn’t rendered properly. Here’s how it looked before:
<img width="694" alt="image" src="https://github.com/user-attachments/assets/dba3fe2c-994d-4868-8ba8-620387de37fa">

### Solution
The rendering logic has been updated to handle rotated text in table cells correctly. Now, rotated text displays as expected:
<img width="711" alt="image" src="https://github.com/user-attachments/assets/866fe68b-8fa5-4d17-8c6e-70019a2e2043">

