### PR TITLE
append counterReset to docx-wrapper only when root element

### DIFF
--- a/src/html-renderer.ts
+++ b/src/html-renderer.ts
@@ -637,8 +637,10 @@ section.${c}>footer { z-index: 1; }
 						"counter-reset": counterReset
 					});
 				}
-				// reset all level counters with start value
-				resetCounters.push(counterReset);
+				// reset all level counters with start value if root layer
+				if(num.level === 0) {
+					resetCounters.push(counterReset);
+				}
 
 				styleText += this.styleToString(`${selector}:before`, {
 					"content": this.levelTextToContent(num.levelText, num.suff, num.id, this.numFormatToCssValue(num.format)),


### PR DESCRIPTION
when counter-reset is applied to the docx-wrapper class, it seems to result in nested numberings never being reset. By only appending resetCounters that are root level, it seems like these issues go away.

This is my first contribution, if you need me to update the unit tests, please give me a brief description how to replace the index.html documents effectively. This PR changes the output so that the unit test fails.

#136 Fixes this issue