### PR TITLE
Add support for nested smart tags

### DIFF
--- a/src/document-parser.ts
+++ b/src/document-parser.ts
@@ -625,6 +625,9 @@ export class DocumentParser {
 				case "r":
 					result.children.push(this.parseRun(c, result));
 					break;
+				case "smartTag":
+					result.children.push(this.parseSmartTag(c, result));
+					break;
 			}
 		}
 


### PR DESCRIPTION
I found a `.docx` file containing nested smart tags like the example below. While Microsoft Word can render the text correctly, the library fails to do so. This pull request fixes that issue.

```xml
<w:smartTag w:uri="urn:schemas-microsoft-com:office:smarttags" w:element="place">
    <w:smartTag w:uri="urn:schemas-microsoft-com:office:smarttags" w:element="City">
        <w:r>
        <w:rPr>
        <w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial"/>
        <w:sz w:val="26"/>
        <w:szCs w:val="26"/>
        </w:rPr>
        <w:t>ICA</w:t>
        </w:r>
    </w:smartTag>
</w:smartTag>
```