### PR TITLE
feat: add chart rendering support to docx parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ renderAsync(
         renderEndnotes: true, //enables endnotes rendering
         renderComments: false, //enables experimental comments rendering
         renderAltChunks: true, //enables altChunks (html parts) rendering
+        /**
+         * Specifies the chart rendering method (e.g., chart1)
+         * chart1: (chart: ChartElement) => IDomChart
+         * 
+         * Line chart rendering method (non-combined chart)
+         * lineChart: (chart: ChartElement) => IDomChart
+         * 
+         * Default rendering method (non-combined chart)
+         * defaultRender: (chart: ChartElement) => IDomChart
+         * 
+         * Mixed chart rendering method
+         * mixedChart: (chart: ChartElement) => IDomChart
+         */
+        renderCharts: Record<string, (chart: ChartElement) => IDomChart>, // Your own chart rendering method implementation, only chart data is provided
         debug: boolean = false, //enables additional logging
     }): Promise<WordDocument>
 

--- a/index.html
+++ b/index.html
@@ -70,7 +70,18 @@
         const docxOptions = Object.assign(docx.defaultOptions, {
             debug: true,
             experimental: true,
-            hideWrapperOnPrint: true
+            hideWrapperOnPrint: true,
+            renderCharts: {
+              defaultRender: (chart) => {
+                const {key, title, catAx, valAx, chartList} = chart;
+                const element = document.createElement("div");
+                element.textContent = title;
+                // just render chart title for demo
+                return {
+                  child: element,
+                };
+              },
+            },
         });
 
         const container = document.querySelector("#document-container");

--- a/src/chart/chart-part.ts
+++ b/src/chart/chart-part.ts
@@ -1,0 +1,18 @@
+import { OpenXmlPackage } from "../common/open-xml-package";
+import { Part } from "../common/part";
+import { DocumentParser } from "../document-parser";
+import { ChartElement } from "./chart";
+
+export class ChartPart extends Part {
+	chart: ChartElement;
+	private _documentParser: DocumentParser;
+
+	constructor(pkg: OpenXmlPackage, path: string, parser: DocumentParser) {
+		super(pkg, path);
+		this._documentParser = parser;
+	}
+
+	parseXml(element: Element) {
+		this.chart = this._documentParser.parseChartElement(element, this.path);
+	}
+}

--- a/src/chart/chart.ts
+++ b/src/chart/chart.ts
@@ -1,0 +1,55 @@
+export interface ChartElement {
+	/**
+	 * Key
+	 */
+	key: string;
+
+	/**
+	 * Title
+	 */
+	title: string;
+
+	/**
+	 * X-axis title
+	 */
+	catAx: string;
+
+	/**
+	 * Y-axis title
+	 */
+	valAx: string;
+
+	/**
+	 * Chart data
+	 */
+	chartList: Chart[];
+}
+
+/**
+ * Chart data
+ */
+export interface Chart {
+	/**
+	 * Chart type
+	 */
+	type: string;
+
+	serList: Ser[];
+}
+
+export interface Ser {
+	/**
+	 * Series title
+	 */
+	title: string;
+
+	/**
+	 * Category list
+	 */
+	catList: string[];
+
+	/**
+	 * Value list
+	 */
+	valList: string[];
+}

--- a/src/common/relationship.ts
+++ b/src/common/relationship.ts
@@ -27,7 +27,8 @@ export enum RelationshipTypes {
 	CustomProperties = "http://schemas.openxmlformats.org/package/2006/relationships/metadata/custom-properties",
 	Comments = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments",
     CommentsExtended = "http://schemas.microsoft.com/office/2011/relationships/commentsExtended",
-    AltChunk = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/aFChunk"
+    AltChunk = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/aFChunk",
+	Chart = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"
 }
 
 export function parseRelationships(root: Element, xml: XmlParser): Relationship[] {

--- a/src/document-parser.ts
+++ b/src/document-parser.ts
@@ -1,6 +1,6 @@
 import {
 	DomType, WmlTable, IDomNumbering,
-	WmlHyperlink, WmlSmartTag, IDomImage, OpenXmlElement, WmlTableColumn, WmlTableCell,
+	WmlHyperlink, WmlSmartTag, IDomImage, IDomChart, OpenXmlElement, WmlTableColumn, WmlTableCell,
 	WmlTableRow, NumberingPicBullet, WmlText, WmlSymbol, WmlBreak, WmlNoteReference,
 	WmlAltChunk
 } from './document/dom';
@@ -16,6 +16,10 @@ import { convertLength, LengthUsage, LengthUsageType } from './document/common';
 import { parseVmlElement } from './vml/vml';
 import { WmlComment, WmlCommentRangeEnd, WmlCommentRangeStart, WmlCommentReference } from './comments/elements';
 import { encloseFontFamily } from './utils';
+import { ChartElement, Chart, Ser } from "./chart/chart";
+import { Relationship } from "./common/relationship";
+import { Part } from "./common/part";
+import { ChartPart } from "./chart/chart-part";
 
 export var autos = {
 	shd: "inherit",
@@ -54,20 +58,30 @@ const mmlTagMap = {
 	"groupChr": DomType.MmlGroupChar
 }
 
+const titlePath = ["title", "tx", "rich", "p", "r", "t"];
+
+const serTitlePath = ["tx", "strRef", "strCache", "pt", "v"];
+
 export interface DocumentParserOptions {
 	ignoreWidth: boolean;
 	debug: boolean;
+    renderCharts: Record<string, (chart: ChartElement) => IDomChart>,
 }
 
 export class DocumentParser {
 	options: DocumentParserOptions;
+	documentRels: Relationship[];
+	chartPartsMap: Record<string, Part>;
 
 	constructor(options?: Partial<DocumentParserOptions>) {
 		this.options = {
 			ignoreWidth: false,
 			debug: false,
+			renderCharts: {},
 			...options
 		};
+		this.documentRels = [];
+		this.chartPartsMap = {};
 	}
 
 	parseNotes(xmlDoc: Element, elemName: string, elemClass: any): any[] {
@@ -940,6 +954,8 @@ export class DocumentParser {
 			switch (n.localName) {
 				case "pic":
 					return this.parsePicture(n);
+				case "chart":
+					return this.parseChart(n);
 			}
 		}
 
@@ -986,6 +1002,50 @@ export class DocumentParser {
 			}
 		}
 
+		return result;
+	}
+
+	parseChartElement(element: Element, path: string): ChartElement {
+		const key = path.split("/").pop().split(".").shift();
+		const chart = xml.element(element, "chart");
+
+		const title = xmlUtil.deepFind(chart, titlePath);
+		const plotArea = xml.element(chart, "plotArea");
+		const catAx = xmlUtil.deepFind(plotArea, ["catAx", ...titlePath]);
+		const valAx = xmlUtil.deepFind(plotArea, ["valAx", ...titlePath]);
+		const charts = xml
+			.elements(plotArea)
+			.filter((el) => xml.element(el, "ser") != null);
+
+		return {
+			key: key,
+			title: xmlUtil.getTextContent(title),
+			catAx: xmlUtil.getTextContent(catAx),
+			valAx: xmlUtil.getTextContent(valAx),
+			chartList: charts.map((chart) => xmlUtil.getChartInfo(chart)),
+		};
+	}
+
+	parseChart(elem: Element): IDomChart {
+		// Get the ID
+		const id = xml.attr(elem, "id");
+		const rel = this.documentRels.find((x) => x.id == id);
+		if (rel == null) {
+			return;
+		}
+		// Get the chartPart
+		const chartPart = this.chartPartsMap[`word/${rel.target}`];
+		if (chartPart == null) {
+			return;
+		}
+		const { chart } = chartPart as ChartPart;
+		// Get the corresponding chart rendering method
+		const renderChart = chartUtil.getRenderChart(this.options.renderCharts, chart);
+		if (renderChart == null) {
+			return;
+		}
+		const result = renderChart(chart) ?? <IDomChart>{ cssStyle: {} };
+		result.type = DomType.Chart;
 		return result;
 	}
 
@@ -1583,6 +1643,60 @@ class xmlUtil {
 
 		return themeColor ? `var(--docx-${themeColor}-color)` : defValue;
 	}
+	static deepFind(elem: Element, path: string[]): Element {
+		if (path.length == 0) {
+			return null;
+		}
+		let currentElem = elem;
+		for (const localName of path) {
+			currentElem = xml.element(currentElem, localName);
+			if (currentElem == null) {
+				return null;
+			}
+		}
+		return currentElem;
+	}
+
+	static getTextContent(elem?: Element): string {
+		return elem != null ? elem.textContent : "";
+	}
+
+	static getChartInfo(elem: Element): Chart {
+		const chartType = elem.localName;
+		const serElements = xml
+			.elements(elem)
+			.filter((el) => el.localName === "ser");
+		const serList: Ser[] = [];
+		for (const serElement of serElements) {
+			const title = this.deepFind(serElement, serTitlePath);
+			const catDataNode = this.deepFind(serElement, [
+				"cat",
+				"strRef",
+				"strCache",
+			]);
+			const valDataNode = this.deepFind(serElement, [
+				"val",
+				"numRef",
+				"numCache",
+			]);
+			serList.push({
+				title: this.getTextContent(title),
+				catList: this.getDataList(catDataNode),
+				valList: this.getDataList(valDataNode),
+			});
+		}
+		return { type: chartType, serList: serList };
+	}
+
+	static getDataList(dataNode?: Element): string[] {
+		if (dataNode == null) {
+			return [];
+		}
+		return xml
+			.elements(dataNode)
+			.filter((el) => el.localName === "pt")
+			.map((el) => this.getTextContent(xml.element(el, "v")));
+	}
 }
 
 class values {
@@ -1728,5 +1842,38 @@ class values {
 		if (xml.boolAttr(c, "noVBand") || (val & 0x0400)) className += " no-vband";
 
 		return className.trim();
+	}
+}
+
+class chartUtil {
+	static getRenderChart(
+		renderCharts: Record<string, (chart: ChartElement) => IDomChart>,
+		chart: ChartElement
+	): (chart: ChartElement) => IDomChart {
+		const { key, chartList = [] } = chart;
+		if (renderCharts[key]) {
+			return renderCharts[key];
+		}
+		// Determine if it is a non-combined chart based on the number of chartList items. More than 1 means it is a non-combined chart.
+		if (chartList.length === 1) {
+			const chart = chartList[0];
+			const { type } = chart;
+			// For non-combined charts, get the rendering method from renderCharts based on the chart type.
+			if (renderCharts[type]) {
+				return renderCharts[type];
+			} else {
+				// If no corresponding rendering method for the chart type is found, use the default render method.
+				if (renderCharts["defaultRender"]) {
+					return renderCharts["defaultRender"];
+				}
+			}
+		} else if (chartList.length > 1) {
+			// For combined charts, get the rendering method with the key "mixedChart" from renderCharts.
+			if (renderCharts["mixedChart"]) {
+				return renderCharts["mixedChart"];
+			}
+		} else {
+			return null;
+		}
 	}
 }

--- a/src/document/document-part.ts
+++ b/src/document/document-part.ts
@@ -1,5 +1,6 @@
 import { OpenXmlPackage } from "../common/open-xml-package";
 import { Part } from "../common/part";
+import { Relationship } from "../common/relationship";
 import { DocumentParser } from "../document-parser";
 import { DocumentElement } from "./document";
 
@@ -15,5 +16,10 @@ export class DocumentPart extends Part {
 
     parseXml(root: Element) {
         this.body = this._documentParser.parseDocumentFile(root);
+    }
+
+	setParserExtraData(rels: Relationship[], chartPartsMap: Record<string, Part>) {
+        this._documentParser.documentRels = rels;
+        this._documentParser.chartPartsMap = chartPartsMap;
     }
 }

--- a/src/document/dom.ts
+++ b/src/document/dom.ts
@@ -60,7 +60,8 @@ export enum DomType {
 	CommentReference = "commentReference",
 	CommentRangeStart = "commentRangeStart",
 	CommentRangeEnd = "commentRangeEnd",
-    AltChunk = "altChunk"
+    AltChunk = "altChunk",
+	Chart = "chart"
 }
 
 export interface OpenXmlElement {
@@ -164,4 +165,8 @@ export interface NumberingPicBullet {
     id: number;
     src: string;
     style?: string;
+}
+
+export interface IDomChart extends OpenXmlElement {
+    child: Node;
 }

--- a/src/docx-preview.ts
+++ b/src/docx-preview.ts
@@ -1,6 +1,8 @@
 import { WordDocument } from './word-document';
 import { DocumentParser } from './document-parser';
 import { HtmlRenderer } from './html-renderer';
+import { ChartElement } from './chart/chart';
+import { IDomChart } from './document/dom';
 
 export interface Options {
     inWrapper: boolean;
@@ -22,6 +24,7 @@ export interface Options {
 	renderChanges: boolean;
     renderComments: boolean;
     renderAltChunks: boolean;
+	renderCharts: Record<string, (chart: ChartElement) => IDomChart>;
 }
 
 export const defaultOptions: Options = {
@@ -43,7 +46,8 @@ export const defaultOptions: Options = {
 	useBase64URL: false,
 	renderChanges: false,
     renderComments: false,
-    renderAltChunks: true
+    renderAltChunks: true,
+	renderCharts: {}
 }
 
 export function parseAsync(data: Blob | any, userOptions?: Partial<Options>): Promise<any>  {

--- a/src/html-renderer.ts
+++ b/src/html-renderer.ts
@@ -1,7 +1,7 @@
 import { WordDocument } from './word-document';
 import {
 	DomType, WmlTable, IDomNumbering,
-	WmlHyperlink, IDomImage, OpenXmlElement, WmlTableColumn, WmlTableCell, WmlText, WmlSymbol, WmlBreak, WmlNoteReference,
+	WmlHyperlink, IDomImage, IDomChart, OpenXmlElement, WmlTableColumn, WmlTableCell, WmlText, WmlSymbol, WmlBreak, WmlNoteReference,
 	WmlSmartTag,
 	WmlAltChunk,
 	WmlTableRow
@@ -878,6 +878,9 @@ section.${c}>footer { z-index: 1; }
 
 			case DomType.AltChunk:
 				return this.renderAltChunk(elem);
+				
+			case DomType.Chart:
+				return this.renderChart(elem as IDomChart);
 		}
 
 		return null;
@@ -1403,6 +1406,16 @@ section.${c}>footer { z-index: 1; }
 		return result;
 	}
 
+	renderChart(elem: IDomChart) {
+		let result = this.createElement("div");
+		this.renderStyleValues(elem.cssStyle, result);
+	
+		if (elem.child) {
+			result.appendChild(elem.child);
+
+		}
+		return result;
+	}
 
 	renderStyleValues(style: Record<string, string>, ouput: HTMLElement) {
 		for (let k in style) {

--- a/src/word-document.ts
+++ b/src/word-document.ts
@@ -18,6 +18,7 @@ import { SettingsPart } from "./settings/settings-part";
 import { CustomPropsPart } from "./document-props/custom-props-part";
 import { CommentsPart } from "./comments/comments-part";
 import { CommentsExtendedPart } from "./comments/comments-extended-part";
+import { ChartPart } from "./chart/chart-part";
 
 const topLevelRels = [
 	{ type: RelationshipTypes.OfficeDocument, target: "word/document.xml" },
@@ -34,6 +35,7 @@ export class WordDocument {
 	rels: Relationship[];
 	parts: Part[] = [];
 	partsMap: Record<string, Part> = {};
+	chartPartsMap: Record<string, Part> = {};
 
 	documentPart: DocumentPart;
 	fontTablePart: FontTablePart;
@@ -60,6 +62,14 @@ export class WordDocument {
 			const r = d.rels.find(x => x.type === rel.type) ?? rel; //fallback                    
 			return d.loadRelationshipPart(r.target, r.type);
 		}));
+
+		if (Object.keys(d.chartPartsMap).length > 0) {
+			d.documentPart.setParserExtraData(
+				d.documentPart.rels,
+				d.chartPartsMap
+			);
+			await d.documentPart.load();
+		}
 
 		return d;
 	}
@@ -136,6 +146,11 @@ export class WordDocument {
 
 			case RelationshipTypes.CommentsExtended:
 				this.commentsExtendedPart = part = new CommentsExtendedPart(this._package, path);
+				break;
+				
+			case RelationshipTypes.Chart:
+				part = new ChartPart(this._package, path, this._parser);
+				this.chartPartsMap[path] = part;
 				break;
 		}
 


### PR DESCRIPTION
- Implement chart parsing functionality in DocumentParser to handle chart elements
- Add Chart relationship type and DomType.Chart enum value
- Create IDomChart interface for chart rendering output
- Implement chart rendering methods in HtmlRenderer
- Add chart parts loading and parsing in WordDocument and DocumentPart
- Include chart parsing utilities for extracting chart data, titles, and series
- Add example implementation in index.html for demo purposes
- Update README.md with chart rendering documentation