### PR TITLE
fix: sanitize hyperlink URIs to prevent XSS

### DIFF
--- a/src/html-renderer.ts
+++ b/src/html-renderer.ts
@@ -960,7 +960,11 @@ section.${c}>footer { z-index: 1; }
 			href += `#${elem.anchor}`;
 		}
 
-		result.href = href;
+		// Only allow safe URI schemes to prevent XSS via javascript:, data:, vbscript:, etc.
+		// Fragment-only anchors (#section) are safe for in-document navigation.
+		if (href && (/^#/.test(href) || /^(https?|mailto):/i.test(href))) {
+			result.href = href;
+		}
 
 		return result;
 	}


### PR DESCRIPTION
## What

Adds protocol validation to `renderHyperlink` to prevent potential XSS via crafted DOCX hyperlinks.

## Why

The `renderHyperlink` function sets `result.href` directly from the DOCX relationship target without validating the URI scheme. A DOCX file with a `javascript:` hyperlink gets rendered as a clickable `<a href="javascript:...">` in the preview.

Applications embedding docx-preview may not have CSP protection, so any script execution would run in the context of the host page with full access to the session.

## Fix

Instead of assigning `href` immediately, the value is first validated against a protocol allowlist (`http:`, `https:`, `mailto:`) or a fragment-only anchor (`#section`). Non-matching URIs (like `javascript:`, `data:`, `vbscript:`) are silently dropped. The `<a>` element is still rendered but without an `href`, so the document structure is preserved.

## Example

A minimal DOCX with a malicious hyperlink relationship in `word/_rels/document.xml.rels`:

```xml
<Relationship Id="rId666"
  Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"
  Target="javascript:alert(document.cookie)"
  TargetMode="External"/>
```

Referenced in `word/document.xml`:

```xml
<w:hyperlink r:id="rId666">
  <w:r><w:t>Click here</w:t></w:r>
</w:hyperlink>
```

**Before fix:** the preview renders `<a href="javascript:alert(document.cookie)">Click here</a>`

**After fix:** the `<a>` tag is rendered without the dangerous `href` since `javascript:` does not match the allowed protocols.