### PR TITLE
fix(numbering): render numbering when multiple num elements share one abstractNum

### DIFF
--- a/src/document-parser.ts
+++ b/src/document-parser.ts
@@ -368,7 +368,7 @@ export class DocumentParser {
 
 	parseNumberingFile(node: Element): IDomNumbering[] {
 		var result = [];
-		var mapping = {};
+		var nums = [];
 		var bullets = [];
 
 		for (const n of xml.elements(node)) {
@@ -383,16 +383,18 @@ export class DocumentParser {
 					break;
 
 				case "num":
-					var numId = xml.attr(n, "numId");
-					var abstractNumId = xml.elementAttr(n, "abstractNumId", "val");
-					mapping[abstractNumId] = numId;
+					nums.push({
+						numId: xml.attr(n, "numId"),
+						abstractNumId: xml.elementAttr(n, "abstractNumId", "val"),
+					});
 					break;
 			}
 		}
 
-		result.forEach(x => x.id = mapping[x.id]);
-
-		return result;
+		// a single abstractNum may be referenced by multiple num elements — clone levels per numId
+		return result.flatMap(level => nums
+			.filter(num => num.abstractNumId == level.id)
+			.map(num => ({ ...level, id: num.numId })));
 	}
 
 	parseNumberingPicBullet(elem: Element): NumberingPicBullet {


### PR DESCRIPTION
Fixes #197.

### Problem
When several `<w:num>` elements reference the **same** `<w:abstractNum>`, `parseNumberingFile` collapses all levels onto a single `numId`, so paragraphs using the other `numId`s render **without numbers**. The `docx-num-{numId}-{lvl}` class is added to the `<p>`, but `renderNumbering` never emits a matching CSS rule for it.

This is valid, common OOXML — Word routinely emits multiple `num` instances sharing one `abstractNum` (heading numbering, list restart/continue). Such documents render correctly in Word / LibreOffice / Google Docs.

### Root cause
The `abstractNumId → numId` map is 1:1 and gets overwritten by the last `num`:

```ts
case "num":
    var numId = xml.attr(n, "numId");
    var abstractNumId = xml.elementAttr(n, "abstractNumId", "val");
    mapping[abstractNumId] = numId;   // last num wins; earlier numIds lose their levels
    break;
...
result.forEach(x => x.id = mapping[x.id]);
```

### Fix
Collect the `num` elements and clone the abstract levels once per referencing `numId`:

```ts
return result.flatMap(level => nums
    .filter(num => num.abstractNumId == level.id)
    .map(num => ({ ...level, id: num.numId })));
```

### Behaviour / compatibility
- Documents with the usual 1:1 `num`→`abstractNum` mapping are unaffected (one num → one copy, identical output).
- Counters are already namespaced via `numberingCounter(id, level)`, so there is no cross-list counter leakage.
- `<w:lvlOverride>` (per-`num` level/start overrides) is still not handled — out of scope; current code does not handle it either.

### Repro
`numbering.xml` with one abstract definition shared by three concrete nums, and a heading style bound to the non-last `numId`:

```xml
<w:abstractNum w:abstractNumId="1"> ... multilevel decimal ... </w:abstractNum>
<w:num w:numId="2"><w:abstractNumId w:val="1"/></w:num>
<w:num w:numId="6"><w:abstractNumId w:val="1"/></w:num>
<w:num w:numId="9"><w:abstractNumId w:val="1"/></w:num>

<w:style w:styleId="Heading1">
  <w:pPr><w:numPr><w:numId w:val="2"/></w:numPr></w:pPr>
</w:style>
```

Before: headings get `docx-num-2-0` but CSS is only generated for `docx-num-9-*` → numbers missing.
After: rules are generated for `numId` 2, 6 and 9 independently → numbers shown.

> Note: only `src/document-parser.ts` is changed; `dist/` is not rebuilt in this PR.
