### PR TITLE
Fix tab stops: style stops, measure-then-apply, and tabs in table cells

### DIFF
--- a/src/html-renderer.ts
+++ b/src/html-renderer.ts
@@ -11,7 +11,7 @@ import { Options } from './docx-preview';
 import { DocumentElement } from './document/document';
 import { WmlParagraph } from './document/paragraph';
 import { asArray, encloseFontFamily, escapeClassName, isString, keyBy, mergeDeep } from './utils';
-import { computePixelToPoint, updateTabStop } from './javascript';
+import { computePixelToPoint, updateTabStops } from './javascript';
 import { FontTablePart } from './font-table/font-table';
 import { FooterHeaderReference, SectionProperties } from './document/section';
 import { WmlRun } from './document/run';
@@ -1438,11 +1438,7 @@ section.${c}>footer { z-index: 1; }
 			return;
 
 		setTimeout(() => {
-			const pixelToPoint = computePixelToPoint();
-
-			for (let tab of this.currentTabs) {
-				updateTabStop(tab.span, tab.stops, this.defaultTabSize, pixelToPoint);
-			}
+			updateTabStops(this.currentTabs, this.defaultTabSize, computePixelToPoint());
 		}, 500);
 	}
 

--- a/src/html-renderer.ts
+++ b/src/html-renderer.ts
@@ -910,10 +910,12 @@ section.${c}>footer { z-index: 1; }
 	}
 
 	renderParagraph(elem: WmlParagraph) {
-		var result = this.toHTML(elem, ns.html, "p");
-
 		const style = this.findStyle(elem.styleName);
-		elem.tabs ??= style?.paragraphProps?.tabs;  //TODO
+		// tab stops have to come from the style before the runs are rendered:
+		// renderTab reads them off the paragraph while it renders
+		elem.tabs ??= style?.paragraphProps?.tabs;
+
+		var result = this.toHTML(elem, ns.html, "p");
 
 		const numbering = elem.numbering ?? style?.paragraphProps?.numbering;
 

--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -21,7 +21,46 @@ export function computePixelToPoint(container: HTMLElement = document.body) {
 	return result
 }
 
+/**
+ * Applying a tab widens its container, and every measurement taken afterwards is
+ * taken against that changed layout: inside a table cell the column grows, more
+ * default stops fit into it, and the next tab grows wider still. So all the tabs
+ * are measured against the untouched layout first and only then applied.
+ */
+export function updateTabStops(tabs: { span: HTMLElement, stops: ParagraphTab[] }[], defaultTabSize: Length, pixelToPoint: number = 72 / 96) {
+	const measured = tabs.map(t => measureTabStop(t.span, t.stops, defaultTabSize, pixelToPoint));
+
+	tabs.forEach((t, i) => measured[i] != null && applyTabStop(t.span, measured[i]));
+}
+
 export function updateTabStop(elem: HTMLElement, tabs: ParagraphTab[], defaultTabSize: Length, pixelToPoint: number = 72 / 96) {
+	const measured = measureTabStop(elem, tabs, defaultTabSize, pixelToPoint);
+
+	if (measured != null)
+		applyTabStop(elem, measured);
+}
+
+function applyTabStop(elem: HTMLElement, { width, leader }: { width: number, leader: string }) {
+    elem.innerHTML = "&nbsp;";
+    elem.style.textDecoration = "inherit";
+    elem.style.wordSpacing = `${width.toFixed(0)}pt`;
+
+    switch (leader) {
+        case "dot":
+        case "middleDot":
+            elem.style.textDecoration = "underline";
+            elem.style.textDecorationStyle = "dotted";
+            break;
+
+        case "hyphen":
+        case "heavy":
+        case "underscore":
+            elem.style.textDecoration = "underline";
+            break;
+    }
+}
+
+function measureTabStop(elem: HTMLElement, tabs: ParagraphTab[], defaultTabSize: Length, pixelToPoint: number) {
     const p = elem.closest("p");
 
     const ebb = elem.getBoundingClientRect();
@@ -51,7 +90,7 @@ export function updateTabStop(elem: HTMLElement, tabs: ParagraphTab[], defaultTa
     const tab = tabStops.find(t => t.style != "clear" && t.pos > left);
 
     if(tab == null)
-        return;
+        return null;
 
     let width: number = 1;
 
@@ -76,23 +115,9 @@ export function updateTabStop(elem: HTMLElement, tabs: ParagraphTab[], defaultTa
         width = tab.pos - left;
     }
 
-    elem.innerHTML = "&nbsp;";
-    elem.style.textDecoration = "inherit";
-    elem.style.wordSpacing = `${width.toFixed(0)}pt`;
-
-    switch (tab.leader) {
-        case "dot":
-        case "middleDot":
-            elem.style.textDecoration = "underline";
-            elem.style.textDecorationStyle = "dotted";
-            break;
-
-        case "hyphen":
-        case "heavy":
-        case "underscore":
-            elem.style.textDecoration = "underline";
-            break;
-    }
+    // a tab never reaches past the right edge of its own paragraph; without this
+    // a stop meant for the page width stretches the table cell that inherited it
+    return { width: Math.min(width, pWidthPt - left), leader: tab.leader };
 }
 
 function lengthToPoint(length: Length): number {


### PR DESCRIPTION
Three defects around tab stops, found on the same documents; they are one subject, so they are here together.

## Reproducing

A custom paragraph style that carries a right tab stop, and a paragraph that uses it:

```xml
<!-- styles.xml -->
<w:style w:type="paragraph" w:customStyle="1" w:styleId="head">
  <w:pPr><w:tabs><w:tab w:val="right" w:pos="8647"/></w:tabs></w:pPr>
</w:style>

<!-- document.xml -->
<w:p>
  <w:pPr><w:pStyle w:val="head"/></w:pPr>
  <w:r><w:t>Left</w:t></w:r><w:r><w:tab/><w:t>Right</w:t></w:r>
</w:p>
```

With `experimental: true`, Word puts `Right` at the right margin; docx-preview renders the tab as `word-spacing: 21pt` — the default tab — and `Right` ends up next to `Left`.

Put a two-column table below it whose cells declare equal widths and contain tabs, and the columns come out unequal: measured 511/164 px where the document declares 233.75pt for both.

## What is wrong

**1. Tab stops from a paragraph style are ignored.** `renderParagraph` rendered the children first and copied the style's stops afterwards:

```ts
var result = this.toHTML(elem, ns.html, "p");   // renderTab runs in here
const style = this.findStyle(elem.styleName);
elem.tabs ??= style?.paragraphProps?.tabs;      // too late
```

`renderTab` reads `findParent(elem, DomType.Paragraph)?.tabs` while it renders, so it saw `undefined` and `updateTabStop` fell back to `defaultTabSize`. Paragraphs that declare their own `<w:tabs>` were unaffected, which is why this only showed up with styles.

**2. Each tab was measured against a layout the previous tab had already changed.** `refreshTabStops` measured and applied one tab at a time. Applying a tab widens its container, so every later measurement was taken against the changed layout. Inside a table cell that compounds: the column grows, more default stops fit into the wider paragraph, and the next tab grows wider still. In the document above, later paragraphs picked up stops at `256, 292, 327, 363` pt that the document never declares — they were generated to fill a width the earlier tabs had created.

**3. A tab could reach past the right edge of its own paragraph.** Word lays the cell out and clips the tab to it; here nothing bounded it, so a stop meant for the page width stretched the cell that inherited it.

## The change

- the style lookup and `elem.tabs ??=` move above `toHTML`;
- `updateTabStops` measures every tab against the untouched layout and applies them afterwards; `updateTabStop` keeps its signature and behaviour, now built from the same two steps;
- a tab's width is bounded by what is left of its paragraph.

## Verifying

`npm run e2e` — 12 passed, no golden file changes. The existing fixtures cannot cover this: `refreshTabStops` applies the widths from a `setTimeout`, as inline styles, after the HTML the tests capture.

On the document that led me here, the header tab goes from `21pt` (default) to `326.67px` (the style's right stop at 8647 twips) and the date moves to the right margin as in Word, while the two-column table below it keeps its columns and its underscore leaders.

---

Written by Claude (Anthropic), working with @DmitrySharabin, who reviewed and tested it.
