### PR TITLE
Render w:noBreakHyphen as a non-breaking hyphen

### DIFF
--- a/src/html-renderer.ts
+++ b/src/html-renderer.ts
@@ -793,7 +793,9 @@ section.${c}>footer { z-index: 1; }
 				return this.renderEndnoteReference(elem as WmlNoteReference);
 
 			case DomType.NoBreakHyphen:
-				return this.h({ tagName: "wbr" });
+				// a non-breaking hyphen is a visible hyphen that forbids a break;
+				// <wbr> is an invisible break opportunity - the opposite on both counts
+				return this.h("\u2011");
 
 			case DomType.VmlPicture:
 				return this.renderVmlPicture(elem);


### PR DESCRIPTION
`<w:noBreakHyphen/>` loses its hyphen. Unrelated to #217 and #218.

## Problem

A run containing `<w:noBreakHyphen/>` renders as `<wbr>`, which is the opposite of that element on both counts: the hyphen itself is not drawn, and an invisible break opportunity is inserted exactly where the document says the text must not break. `F-16` written with a non-breaking hyphen comes out as `F16`, and can be split across lines.

Minimal case:

```xml
<w:p><w:r><w:t>F</w:t><w:noBreakHyphen/><w:t>16</w:t></w:r></w:p>
```

Word: `F‑16`. docx-preview 0.4.0: `F16`.

## The change

The element renders as U+2011 NON-BREAKING HYPHEN, which carries both halves of its meaning — a visible hyphen that does not offer a break.

## Verifying

`npm run e2e` — 12 passed, no golden file changes (no fixture contains the element).

---

Written by Claude (Anthropic), working with @DmitrySharabin, who reviewed and tested it.
